### PR TITLE
Improve demo performance

### DIFF
--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -36,6 +36,7 @@ export const HowItWorks: React.FC = () => (
             <img
               src={image}
               alt={alt}
+              loading="lazy"
               className="mx-auto mb-4 h-150 w-150 object-contain rounded"
             />
             <h3 className="font-semibold">{title}</h3>

--- a/src/components/PhoneMock.tsx
+++ b/src/components/PhoneMock.tsx
@@ -310,6 +310,7 @@ const PhoneMockup: React.FC = () => {
               <img
                 src={item.image}
                 alt={item.name}
+                loading="lazy"
                 className="w-full aspect-square object-cover rounded-lg mb-2"
               />
               <h3 className="text-sm font-semibold text-center leading-tight">
@@ -391,6 +392,7 @@ const PhoneMockup: React.FC = () => {
             <img
               src={cat.icon}
               alt={cat.name}
+              loading="lazy"
               className="w-6 h-6 mb-1 object-contain"
             />
             {cat.name}
@@ -494,6 +496,7 @@ const PhoneMockup: React.FC = () => {
                         <img
                           src={item.image}
                           alt={item.name}
+                          loading="lazy"
                           className="w-12 h-12 rounded object-cover"
                         />
                         <div>
@@ -559,6 +562,7 @@ const PhoneMockup: React.FC = () => {
               <img
                 src={selectedItem.image}
                 alt={selectedItem.name}
+                loading="lazy"
                 className="w-full h-44 object-cover"
               />
               <button

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -29,6 +29,7 @@ export const AboutPage: React.FC = () => {
         <img
           src={planten2}
           alt="About Hero"
+          loading="lazy"
           className="w-full h-full object-cover object-center"
         />
         <div className="absolute inset-0 bg-[#2C1E1A]/20 flex items-center justify-center">

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -37,6 +37,7 @@ export const ContactPage: React.FC = () => {
         <img
           src={planten2}
           alt="Contact Hero"
+          loading="lazy"
           className="w-full h-full object-cover object-center"
         />
         <div className="absolute inset-0 bg-[#2C1E1A]/20 flex items-center justify-center">

--- a/src/pages/FeaturePage.tsx
+++ b/src/pages/FeaturePage.tsx
@@ -88,6 +88,7 @@ export const FeaturePage: React.FC = () => {
         <img
           src={planten2}
           alt="Hero"
+          loading="lazy"
           className="w-full h-full object-cover object-center"
         />
         <div className="absolute inset-0 bg-[#2C1E1A]/20 flex items-center justify-center">

--- a/src/pages/LandingPage/Benefits.tsx
+++ b/src/pages/LandingPage/Benefits.tsx
@@ -75,6 +75,7 @@ export const BenefitsOne: React.FC = () => {
           <img
             src={tabletechPhoneImg}
             alt="TableTech app mockup"
+            loading="lazy"
             className="w-full max-w-[300px] rounded-3xl shadow-xl"
           />
         </div>
@@ -101,6 +102,7 @@ export const BenefitsOne: React.FC = () => {
                   <img
                     src={imgSrc}
                     alt={alt}
+                    loading="lazy"
                     className="mx-auto mb-6 h-28 w-28 object-cover rounded-full shadow-md transition duration-300 group-hover:-translate-y-1 group-hover:ring-4 group-hover:ring-[#e9d7c2]"
                   />
                 </div>

--- a/src/pages/LandingPage/DashboardPreview.tsx
+++ b/src/pages/LandingPage/DashboardPreview.tsx
@@ -43,6 +43,7 @@ export const DashboardPreview: React.FC = () => {
             <img
               src={dashboardImg}
               alt="Dashboard weergave"
+              loading="lazy"
               className="w-full lg:w-1/2 max-w-sm rounded-2xl shadow-xl border border-[#D3C3B6]/40 transition-transform duration-300 hover:scale-105 hover:shadow-2xl"
             />
             <video
@@ -50,6 +51,7 @@ export const DashboardPreview: React.FC = () => {
               muted
               loop
               playsInline
+              preload="metadata"
               className="w-full lg:w-1/2 max-w-sm rounded-xl shadow-lg border border-[#D3C3B6]/40 transition-transform duration-300 hover:scale-105 hover:shadow-2xl"
             >
               <source src="/videos/Qr Code.mp4" type="video/mp4" />

--- a/src/pages/LandingPage/HeroSection.tsx
+++ b/src/pages/LandingPage/HeroSection.tsx
@@ -46,6 +46,7 @@ export const HeroSection: React.FC = () => {
           muted
           loop
           playsInline
+          preload="metadata"
           className="absolute inset-0 w-full h-full object-cover"
         >
           <source src="/videos/background-2.webm" type="video/webm" />

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -37,6 +37,7 @@ export const PricingPage: React.FC = () => {
         <img
           src={planten2}
           alt="Pricing Hero"
+          loading="lazy"
           className="w-full h-full object-cover object-center"
         />
         <div className="absolute inset-0 bg-[#2C1E1A]/20 flex items-center justify-center">

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -14,7 +14,12 @@ export const PrivacyPolicyPage: React.FC = () => {
 
       {/* Hero */}
       <div className="relative w-full h-[60vh] overflow-hidden">
-        <img src={planten2} alt="Privacy Hero" className="w-full h-full object-cover object-center" />
+        <img
+          src={planten2}
+          alt="Privacy Hero"
+          loading="lazy"
+          className="w-full h-full object-cover object-center"
+        />
         <div className="absolute inset-0 bg-[#2C1E1A]/20 flex items-center justify-center">
           <h1 className="text-4xl md:text-5xl font-bold text-white drop-shadow-lg">
             Privacybeleid


### PR DESCRIPTION
## Summary
- add lazy loading for images across pages and components
- preload hero and dashboard videos for smoother demo experience

## Testing
- `npm install`
- `npm test` *(fails: vitest runs in watch mode and requires exit)*

------
https://chatgpt.com/codex/tasks/task_e_684077fcc32c8326aa336816eb5cbb2b