### PR TITLE
Improve Benefits layout

### DIFF
--- a/src/pages/LandingPage/Benefits.tsx
+++ b/src/pages/LandingPage/Benefits.tsx
@@ -42,7 +42,7 @@ export default function BenefitsOne() {
               <img
                 src="/menu/menu1.jpg"
                 alt="Prawn Raisukaree"
-                className="w-full h-5 object-cover rounded mb-0.5"
+                className="w-full h-8 object-contain rounded mb-0.5"
               />
               <h4 className="text-xs font-bold mb-0.5 text-gray-800">Prawn Raisukaree</h4>
               <p className="text-xs text-gray-600 mb-0.5">Verse garnalen, rijst</p>
@@ -58,7 +58,7 @@ export default function BenefitsOne() {
               <img
                 src="/menu/menu3.jpg"
                 alt="Chicken Katsu Curry"
-                className="w-full h-5 object-cover rounded mb-0.5"
+                className="w-full h-8 object-contain rounded mb-0.5"
               />
               <h4 className="text-xs font-bold mb-0.5 text-gray-800">Chicken Katsu Curry</h4>
               <p className="text-xs text-gray-600 mb-0.5">Krokante kip, curry</p>
@@ -74,7 +74,7 @@ export default function BenefitsOne() {
               <img
                 src="/menu/menu2.jpg"
                 alt="Firecracker Prawn"
-                className="w-full h-5 object-cover rounded mb-0.5"
+                className="w-full h-8 object-contain rounded mb-0.5"
               />
               <h4 className="text-xs font-bold mb-0.5 text-gray-800">Firecracker Prawn</h4>
               <p className="text-xs text-gray-600 mb-0.5">Pittige garnalen</p>
@@ -90,7 +90,7 @@ export default function BenefitsOne() {
               <img
                 src="/menu/menu5.jpg"
                 alt="Fresh Lemonade"
-                className="w-full h-5 object-cover rounded mb-0.5"
+                className="w-full h-8 object-contain rounded mb-0.5"
               />
               <h4 className="text-xs font-bold mb-0.5 text-gray-800">Fresh Lemonade</h4>
               <p className="text-xs text-gray-600 mb-0.5">Verse citroen, munt</p>
@@ -622,61 +622,12 @@ export default function BenefitsOne() {
       {/* Main content */}
       <div className="relative z-10 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-12">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-center">
-          
-          {/* Left side - Interactive Phone */}
-          <div className="relative flex items-center justify-center">
-            <div className="relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-3xl blur-3xl scale-110 opacity-20" />
-              
-              <motion.div
-                className="relative w-64 h-80 bg-black rounded-3xl p-2 shadow-2xl"
-                animate={{
-                  y: [0, -8, 0],
-                }}
-                transition={{
-                  duration: 6,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              >
-                <div className="absolute top-4 left-1/2 transform -translate-x-1/2 w-20 h-1 bg-gray-600 rounded-full z-30" />
-                
-                <div className="w-full h-full bg-gray-900 rounded-2xl overflow-hidden relative">
-                  <AnimatePresence mode="wait">
-                    <motion.div
-                      key={currentScreen}
-                      initial={{ opacity: 0, scale: 0.95 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 1.05 }}
-                      transition={{ duration: 0.8 }}
-                      className="absolute inset-0 p-1"
-                    >
-                      {appScreens[currentScreen].content}
-                    </motion.div>
-                  </AnimatePresence>
-                </div>
-              </motion.div>
 
-              <div className="absolute -bottom-8 left-1/2 transform -translate-x-1/2 flex space-x-2">
-                {appScreens.map((_, index) => (
-                  <motion.button
-                    key={index}
-                    onClick={() => setCurrentScreen(index)}
-                    className={`w-2 h-2 rounded-full transition-all duration-300 ${
-                      currentScreen === index ? 'bg-white scale-125' : 'bg-white/50'
-                    }`}
-                    whileHover={{ scale: 1.2 }}
-                  />
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Center - Tablet Dashboard */}
+          {/* Left side - Tablet Dashboard */}
           <div className="relative flex items-center justify-center">
             <div className="relative">
               <div className="absolute inset-0 bg-gradient-to-r from-slate-600 to-slate-800 rounded-2xl blur-3xl scale-110 opacity-30" />
-              
+
               <motion.div
                 className="relative w-96 h-72 bg-black rounded-2xl p-1 shadow-2xl"
                 animate={{
@@ -719,7 +670,7 @@ export default function BenefitsOne() {
             </div>
           </div>
 
-          {/* Right side - Description */}
+          {/* Center - Description */}
           <div className="space-y-6">
             <motion.div
               initial={{ opacity: 0, y: 30 }}
@@ -770,6 +721,55 @@ export default function BenefitsOne() {
                   </p>
                 </motion.div>
               </AnimatePresence>
+            </div>
+          </div>
+
+          {/* Right side - Interactive Phone */}
+          <div className="relative flex items-center justify-center">
+            <div className="relative">
+              <div className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-3xl blur-3xl scale-110 opacity-20" />
+
+              <motion.div
+                className="relative w-64 h-80 bg-black rounded-3xl p-2 shadow-2xl"
+                animate={{
+                  y: [0, -8, 0],
+                }}
+                transition={{
+                  duration: 6,
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                }}
+              >
+                <div className="absolute top-4 left-1/2 transform -translate-x-1/2 w-20 h-1 bg-gray-600 rounded-full z-30" />
+
+                <div className="w-full h-full bg-gray-900 rounded-2xl overflow-hidden relative">
+                  <AnimatePresence mode="wait">
+                    <motion.div
+                      key={currentScreen}
+                      initial={{ opacity: 0, scale: 0.95 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 1.05 }}
+                      transition={{ duration: 0.8 }}
+                      className="absolute inset-0 p-1"
+                    >
+                      {appScreens[currentScreen].content}
+                    </motion.div>
+                  </AnimatePresence>
+                </div>
+              </motion.div>
+
+              <div className="absolute -bottom-8 left-1/2 transform -translate-x-1/2 flex space-x-2">
+                {appScreens.map((_, index) => (
+                  <motion.button
+                    key={index}
+                    onClick={() => setCurrentScreen(index)}
+                    className={`w-2 h-2 rounded-full transition-all duration-300 ${
+                      currentScreen === index ? 'bg-white scale-125' : 'bg-white/50'
+                    }`}
+                    whileHover={{ scale: 1.2 }}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorder benefits section to show dashboard first, text middle, phone last
- make menu images larger and fully visible

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840dec57d3c83269c2e55833746e51f