### PR TITLE
Optimize page loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,19 @@
 // src/App.tsx
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router-dom";
 
-import LandingPage from "./pages/LandingPage/LandingPage";
-import { FeaturePage } from "./pages/FeaturePage";
-import { PricingPage } from "./pages/PricingPage";
-import { AboutPage } from "./pages/AboutPage";
-import { ContactPage } from "./pages/ContactPage";
-import { PrivacyPolicyPage } from "./pages/PrivacyPolicyPage";
+const LandingPage = lazy(() => import("./pages/LandingPage/LandingPage"));
+const FeaturePage = lazy(() => import("./pages/FeaturePage"));
+const PricingPage = lazy(() => import("./pages/PricingPage"));
+const AboutPage = lazy(() => import("./pages/AboutPage"));
+const ContactPage = lazy(() => import("./pages/ContactPage"));
+const PrivacyPolicyPage = lazy(() => import("./pages/PrivacyPolicyPage"));
+const SupportChat = lazy(() => import("./pages/SupportChat"));
+const KlantDemoPage = lazy(() => import("./pages/KlantDemoPage"));
+const RestaurantThemesPage = lazy(() => import("./pages//LandingPage/restaurant-themes"));
+
 import ScrollToTop from "./components/ScrollToTop";
 import { ScrollDots } from "./components/ScrollDotss";
-import { SupportChat } from "./pages/SupportChat";
-import KlantDemoPage from "./pages/KlantDemoPage";
-import RestaurantThemesPage from "./pages//LandingPage/restaurant-themes";
 
 import "./index.css";
 
@@ -23,16 +24,18 @@ const App: React.FC = () => {
       <ScrollDots />
       <SupportChat />
       
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/features" element={<FeaturePage />} />
-        <Route path="/pricing" element={<PricingPage />} />
-        <Route path="/about" element={<AboutPage />} />
-        <Route path="/contact" element={<ContactPage />} />
-        <Route path="/privacy" element={<PrivacyPolicyPage />} />
-        <Route path="/demo" element={<KlantDemoPage />} />
-        <Route path="/themes" element={<RestaurantThemesPage />} />
-      </Routes>
+      <Suspense fallback={<div className="flex h-screen items-center justify-center">Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/features" element={<FeaturePage />} />
+          <Route path="/pricing" element={<PricingPage />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/contact" element={<ContactPage />} />
+          <Route path="/privacy" element={<PrivacyPolicyPage />} />
+          <Route path="/demo" element={<KlantDemoPage />} />
+          <Route path="/themes" element={<RestaurantThemesPage />} />
+        </Routes>
+      </Suspense>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- enable React.lazy on main pages
- add Suspense fallback during lazy loading

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bed466cc8326a7fab5cd79ca28b7